### PR TITLE
fix a bug when copying T1/FLAIR after gunzipping

### DIFF
--- a/WMH_extraction/cmd/WMHext/WMHextraction_woQC_cmd.m
+++ b/WMH_extraction/cmd/WMHext/WMHextraction_woQC_cmd.m
@@ -92,8 +92,8 @@ function WMHextraction_woQC_cmd (studyFolder, ...
             CNSP_gunzipnii ([studyFolder '/originalImg/FLAIR/' FLAIRfolder(i).name]);
 
             mkdir (strcat(studyFolder,'/subjects/',ID,'/mri'),'orig');  % create orig folder under each subject folder
-            copyfile (strcat (studyFolder,'/originalImg/T1/', T1folder(i).name), strcat(studyFolder,'/subjects/',ID,'/mri/orig/'));        % copy T1 to each subject folder
-            copyfile (strcat (studyFolder,'/originalImg/FLAIR/', FLAIRfolder(i).name), strcat(studyFolder,'/subjects/',ID,'/mri/orig/'));  % copy FLAIR to each subject folder
+            copyfile (strcat (studyFolder,'/originalImg/T1/', ID, '_T1.nii'), strcat(studyFolder,'/subjects/',ID,'/mri/orig/'));        % copy T1 to each subject folder
+            copyfile (strcat (studyFolder,'/originalImg/FLAIR/', ID, '_FLAIR.nii'), strcat(studyFolder,'/subjects/',ID,'/mri/orig/'));  % copy FLAIR to each subject folder
 
         
             %%%%%%%%%%%%%%%%%


### PR DESCRIPTION
This was a minor bug in WMHextraction_woQC_cmd.m. If image had to be gunzipped, the image filename extension changes from .nii.gz to .nii. Thus, the variable T1/FLAIRfolder(i).name has to be modified to reflect the change... My fix is based on the assumption that the user renamed their files according the instruction in the manual (i.e. (sub_id)_T1/FLAIR.nii), but this is not checked when files are being moved around, so my fix will break if they did not follow the naming convention.

BTW, why is it necessary to move around the input images so many times (Study dir --> originalImg --> subjects/mri/orig)? Why not keep one copy of original image (that may be gunzipped) in one input dir (either Study dir or originalImg) and leave it untouched, and place unzipped one in another?